### PR TITLE
Implementar geração, persistência e validação de token de segurança

### DIFF
--- a/docs/postman/2FA.local.postman_environment.json
+++ b/docs/postman/2FA.local.postman_environment.json
@@ -1,0 +1,23 @@
+{
+  "id": "f1b4c3d7-4e54-4c9d-bc1b-7b1a7a9f0c1a",
+  "name": "2FA Local",
+  "values": [
+    { "key": "baseUrl", "value": "http://localhost:8080", "enabled": true },
+    { "key": "username", "value": "user1", "enabled": true },
+    { "key": "password", "value": "Nova@123", "enabled": true },
+    { "key": "newPassword", "value": "Nova@123", "enabled": true },
+    { "key": "userId", "value": "1", "enabled": true },
+    { "key": "resetPasswordLink", "value": "", "enabled": true },
+    { "key": "resetPasswordToken", "value": "", "enabled": true },
+    { "key": "resetTokenValid", "value": "", "enabled": true },
+    { "key": "loginToken", "value": "", "enabled": true },
+    { "key": "tokenExpiresAt", "value": "", "enabled": true },
+    { "key": "requiresToken", "value": "", "enabled": true },
+    { "key": "accessToken", "value": "", "enabled": true },
+    { "key": "refreshToken", "value": "", "enabled": true }
+  ],
+  "_postman_variable_scope": "environment",
+  "_postman_exported_at": "2025-09-25T00:00:00.000Z",
+  "_postman_exported_using": "Postman/10.x"
+}
+

--- a/docs/postman/2FA.postman_collection.json
+++ b/docs/postman/2FA.postman_collection.json
@@ -6,55 +6,22 @@
   },
   "item": [
     {
-      "name": "2FA - Primeiro Acesso",
+      "name": "2FA - Primeiro Acesso (Cadastro de Senha)",
       "item": [
         {
-          "name": "Password Reset - Generate (obter link)",
+          "name": "First Password - Definir senha",
           "request": {
             "method": "POST",
-            "header": [
-              { "key": "Content-Type", "value": "application/json" }
-            ],
+            "header": [ { "key": "Content-Type", "value": "application/json" } ],
             "url": {
-              "raw": "{{baseUrl}}/api/auth/password-reset/generate",
+              "raw": "{{baseUrl}}/api/v1/auth/first-password",
               "host": ["{{baseUrl}}"],
-              "path": ["api", "auth", "password-reset", "generate"]
+              "path": ["api", "v1", "auth", "first-password"]
             },
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"login\": \"{{username}}\"\n}",
+              "raw": "{\n  \"userId\": {{userId}},\n  \"password\": \"{{newPassword}}\",\n  \"passwordConfirmation\": \"{{newPassword}}\"\n}",
               "options": { "raw": { "language": "json" } }
-            }
-          },
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "let json = {};",
-                  "try { json = pm.response.json(); } catch (e) {}",
-                  "if (json && json.resetLink) {",
-                  "  pm.environment.set('resetPasswordLink', json.resetLink);",
-                  "  const parts = json.resetLink.split('token=');",
-                  "  if (parts.length > 1) { pm.environment.set('resetPasswordToken', parts[1]); }",
-                  "}",
-                  "pm.test('Status 200 ou 404 (login inexistente)', function () { pm.expect([200,404]).to.include(pm.response.code); });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ]
-        },
-        {
-          "name": "Password Reset - Validate (checar token de reset)",
-          "request": {
-            "method": "GET",
-            "header": [],
-            "url": {
-              "raw": "{{baseUrl}}/api/auth/password-reset/validate?token={{resetPasswordToken}}",
-              "host": ["{{baseUrl}}"],
-              "path": ["api", "auth", "password-reset", "validate"],
-              "query": [ { "key": "token", "value": "{{resetPasswordToken}}" } ]
             }
           },
           "event": [
@@ -64,39 +31,7 @@
                 "exec": [
                   "pm.test('Status 200', function () { pm.response.to.have.status(200); });",
                   "const json = pm.response.json();",
-                  "pm.environment.set('resetTokenValid', String(json.valid));"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ]
-        },
-        {
-          "name": "Password Reset - Reset (definir senha)",
-          "request": {
-            "method": "POST",
-            "header": [ { "key": "Content-Type", "value": "application/json" } ],
-            "url": {
-              "raw": "{{baseUrl}}/api/auth/password-reset/reset",
-              "host": ["{{baseUrl}}"],
-              "path": ["api", "auth", "password-reset", "reset"]
-            },
-            "body": {
-              "mode": "raw",
-              "raw": "{\n  \"token\": \"{{resetPasswordToken}}\",\n  \"newPassword\": \"{{newPassword}}\",\n  \"confirmPassword\": \"{{newPassword}}\"\n}",
-              "options": { "raw": { "language": "json" } }
-            }
-          },
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('Status 200 ou 400', function () { pm.expect([200,400]).to.include(pm.response.code); });",
-                  "const json = pm.response.json();",
-                  "pm.environment.set('resetSuccess', String(json.success));",
-                  "if (json.accessToken) pm.environment.set('accessToken', json.accessToken);",
-                  "if (json.refreshToken) pm.environment.set('refreshToken', json.refreshToken);"
+                  "const requires = json.requiresToken === true; pm.environment.set('requiresToken', String(requires));"
                 ],
                 "type": "text/javascript"
               }

--- a/docs/postman/2FA.postman_collection.json
+++ b/docs/postman/2FA.postman_collection.json
@@ -1,0 +1,302 @@
+{
+  "info": {
+    "_postman_id": "b8a3b2e2-3e3a-4f2a-9d1d-2f6d78c4a1a1",
+    "name": "2FA - Login Token (Primeiro Acesso e Login)",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "item": [
+    {
+      "name": "2FA - Primeiro Acesso",
+      "item": [
+        {
+          "name": "Password Reset - Generate (obter link)",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/auth/password-reset/generate",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "auth", "password-reset", "generate"]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"login\": \"{{username}}\"\n}",
+              "options": { "raw": { "language": "json" } }
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "let json = {};",
+                  "try { json = pm.response.json(); } catch (e) {}",
+                  "if (json && json.resetLink) {",
+                  "  pm.environment.set('resetPasswordLink', json.resetLink);",
+                  "  const parts = json.resetLink.split('token=');",
+                  "  if (parts.length > 1) { pm.environment.set('resetPasswordToken', parts[1]); }",
+                  "}",
+                  "pm.test('Status 200 ou 404 (login inexistente)', function () { pm.expect([200,404]).to.include(pm.response.code); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "Password Reset - Validate (checar token de reset)",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/api/auth/password-reset/validate?token={{resetPasswordToken}}",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "auth", "password-reset", "validate"],
+              "query": [ { "key": "token", "value": "{{resetPasswordToken}}" } ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Status 200', function () { pm.response.to.have.status(200); });",
+                  "const json = pm.response.json();",
+                  "pm.environment.set('resetTokenValid', String(json.valid));"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "Password Reset - Reset (definir senha)",
+          "request": {
+            "method": "POST",
+            "header": [ { "key": "Content-Type", "value": "application/json" } ],
+            "url": {
+              "raw": "{{baseUrl}}/api/auth/password-reset/reset",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "auth", "password-reset", "reset"]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"token\": \"{{resetPasswordToken}}\",\n  \"newPassword\": \"{{newPassword}}\",\n  \"confirmPassword\": \"{{newPassword}}\"\n}",
+              "options": { "raw": { "language": "json" } }
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Status 200 ou 400', function () { pm.expect([200,400]).to.include(pm.response.code); });",
+                  "const json = pm.response.json();",
+                  "pm.environment.set('resetSuccess', String(json.success));",
+                  "if (json.accessToken) pm.environment.set('accessToken', json.accessToken);",
+                  "if (json.refreshToken) pm.environment.set('refreshToken', json.refreshToken);"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "2FA Token - Generate (debug - cria/mostra token)",
+          "request": {
+            "method": "POST",
+            "header": [ { "key": "Content-Type", "value": "application/json" } ],
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/auth/generate-token",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "v1", "auth", "generate-token"]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"userId\": {{userId}}\n}",
+              "options": { "raw": { "language": "json" } }
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Status 200', function () { pm.response.to.have.status(200); });",
+                  "const json = pm.response.json();",
+                  "if (json.token) pm.environment.set('loginToken', json.token);",
+                  "if (json.expiresAt) pm.environment.set('tokenExpiresAt', json.expiresAt);"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "2FA Token - Validate (primeiro acesso)",
+          "request": {
+            "method": "POST",
+            "header": [ { "key": "Content-Type", "value": "application/json" } ],
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/auth/validate-token",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "v1", "auth", "validate-token"]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"userId\": {{userId}},\n  \"token\": \"{{loginToken}}\"\n}",
+              "options": { "raw": { "language": "json" } }
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Status 200 ou 401', function () { pm.expect([200,401]).to.include(pm.response.code); });",
+                  "if (pm.response.code === 200) { const json = pm.response.json(); if (json.accessToken) pm.environment.set('accessToken', json.accessToken); if (json.token) pm.environment.set('refreshToken', json.token); }"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "2FA - Login",
+      "item": [
+        {
+          "name": "Login (verificar se exige token)",
+          "request": {
+            "method": "POST",
+            "header": [ { "key": "Content-Type", "value": "application/json" } ],
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/auth/login",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "v1", "auth", "login"]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"username\": \"{{username}}\",\n  \"password\": \"{{password}}\"\n}",
+              "options": { "raw": { "language": "json" } }
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Status 200', function () { pm.response.to.have.status(200); });",
+                  "const json = pm.response.json();",
+                  "const requires = json.requiresToken === true; pm.environment.set('requiresToken', String(requires));",
+                  "if (!requires) { if (json.accessToken) pm.environment.set('accessToken', json.accessToken); if (json.token) pm.environment.set('refreshToken', json.token); }"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "2FA Token - Generate (debug - cria/mostra token)",
+          "request": {
+            "method": "POST",
+            "header": [ { "key": "Content-Type", "value": "application/json" } ],
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/auth/generate-token",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "v1", "auth", "generate-token"]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"userId\": {{userId}}\n}",
+              "options": { "raw": { "language": "json" } }
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Status 200', function () { pm.response.to.have.status(200); });",
+                  "const json = pm.response.json();",
+                  "if (json.token) pm.environment.set('loginToken', json.token);",
+                  "if (json.expiresAt) pm.environment.set('tokenExpiresAt', json.expiresAt);"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "2FA Token - Validate (login)",
+          "request": {
+            "method": "POST",
+            "header": [ { "key": "Content-Type", "value": "application/json" } ],
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/auth/validate-token",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "v1", "auth", "validate-token"]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"userId\": {{userId}},\n  \"token\": \"{{loginToken}}\"\n}",
+              "options": { "raw": { "language": "json" } }
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Status 200 ou 401', function () { pm.expect([200,401]).to.include(pm.response.code); });",
+                  "if (pm.response.code === 200) { const json = pm.response.json(); if (json.accessToken) pm.environment.set('accessToken', json.accessToken); if (json.token) pm.environment.set('refreshToken', json.token); }"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "2FA - Casos Negativos",
+      "item": [
+        {
+          "name": "Validate Token - Token inválido",
+          "request": {
+            "method": "POST",
+            "header": [ { "key": "Content-Type", "value": "application/json" } ],
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/auth/validate-token",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "v1", "auth", "validate-token"]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"userId\": {{userId}},\n  \"token\": \"xxxxx\"\n}",
+              "options": { "raw": { "language": "json" } }
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Retorna 401 TOKEN_INVALIDO', function () { pm.response.to.have.status(401); const json = pm.response.json(); pm.expect(json.error).to.eql('TOKEN_INVALIDO'); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "variable": [
+    { "key": "baseUrl", "value": "http://localhost:8080" }
+  ]
+}
+

--- a/src/main/java/com/montreal/oauth/controller/RegistrationController.java
+++ b/src/main/java/com/montreal/oauth/controller/RegistrationController.java
@@ -1,0 +1,76 @@
+package com.montreal.oauth.controller;
+
+import com.montreal.oauth.domain.dto.request.FirstPasswordRequest;
+import com.montreal.oauth.domain.dto.JwtResponseDTO;
+import com.montreal.oauth.domain.entity.UserInfo;
+import com.montreal.oauth.domain.service.UserService;
+import com.montreal.oauth.domain.service.UserTokenService;
+import com.montreal.oauth.domain.service.JwtService;
+import com.montreal.oauth.domain.service.RefreshTokenService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/v1/auth")
+@RequiredArgsConstructor
+@Tag(name = "Registro", description = "Fluxo de primeiro cadastro de senha (primeiro acesso)")
+public class RegistrationController {
+
+    private final UserService userService;
+    private final UserTokenService userTokenService;
+    private final JwtService jwtService;
+    private final RefreshTokenService refreshTokenService;
+
+    @Operation(summary = "Definir senha no primeiro acesso")
+    @PostMapping("/first-password")
+    public ResponseEntity<?> setFirstPassword(@Valid @RequestBody FirstPasswordRequest request) {
+        try {
+            UserInfo user = userService.getUserById(request.getUserId());
+
+            if (user.isPasswordChangedByUser()) {
+                return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("Senha já foi definida anteriormente");
+            }
+
+            // Define a primeira senha
+            userService.changePassword(user.getId(), request.getPassword());
+
+            // Se a role exigir token no primeiro acesso, gerar e sinalizar ao cliente
+            boolean requiresFirstToken = user.getRoles().stream().anyMatch(r -> Boolean.TRUE.equals(r.getRequiresTokenFirstLogin()));
+            if (requiresFirstToken) {
+                userTokenService.generateAndPersist(userService.getUserById(user.getId()));
+                JwtResponseDTO response = JwtResponseDTO.builder()
+                        .accessToken(null)
+                        .token(null)
+                        .userDetails(null)
+                        .requiresToken(true)
+                        .build();
+                return ResponseEntity.ok(response);
+            }
+
+            // Caso não exija token no primeiro acesso, retorna tokens de login automático
+            String accessToken = jwtService.GenerateToken(user.getUsername());
+            String refreshToken = refreshTokenService.getTokenByUserId(user.getId());
+            if (refreshToken.isEmpty()) {
+                refreshToken = refreshTokenService.createRefreshToken(user.getUsername()).getToken();
+            }
+
+            JwtResponseDTO response = JwtResponseDTO.builder()
+                    .accessToken(accessToken)
+                    .token(refreshToken)
+                    .build();
+            return ResponseEntity.ok(response);
+
+        } catch (Exception e) {
+            log.error("Erro ao definir primeira senha", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("Erro ao definir primeira senha");
+        }
+    }
+}
+

--- a/src/main/java/com/montreal/oauth/domain/dto/request/FirstPasswordRequest.java
+++ b/src/main/java/com/montreal/oauth/domain/dto/request/FirstPasswordRequest.java
@@ -1,0 +1,25 @@
+package com.montreal.oauth.domain.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class FirstPasswordRequest {
+
+    @NotNull
+    private Long userId;
+
+    @NotBlank
+    private String password;
+
+    @NotBlank
+    private String passwordConfirmation;
+}
+

--- a/src/main/java/com/montreal/oauth/domain/entity/FirstAccessToken.java
+++ b/src/main/java/com/montreal/oauth/domain/entity/FirstAccessToken.java
@@ -1,0 +1,55 @@
+package com.montreal.oauth.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "first_access_tokens")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class FirstAccessToken {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "token", unique = true, nullable = false, length = 255)
+    private String token;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private UserInfo user;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "expires_at", nullable = false)
+    private LocalDateTime expiresAt;
+
+    @Column(name = "used_at")
+    private LocalDateTime usedAt;
+
+    @Column(name = "is_used", nullable = false)
+    private boolean isUsed = false;
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = LocalDateTime.now();
+    }
+
+    public boolean isExpired() {
+        return LocalDateTime.now().isAfter(expiresAt);
+    }
+
+    public boolean isValid() {
+        return !isExpired() && !isUsed;
+    }
+}
+

--- a/src/main/java/com/montreal/oauth/domain/repository/IFirstAccessTokenRepository.java
+++ b/src/main/java/com/montreal/oauth/domain/repository/IFirstAccessTokenRepository.java
@@ -1,0 +1,24 @@
+package com.montreal.oauth.domain.repository;
+
+import com.montreal.oauth.domain.entity.FirstAccessToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+public interface IFirstAccessTokenRepository extends JpaRepository<FirstAccessToken, Long> {
+
+    @Query("select t from FirstAccessToken t where t.token = :token")
+    Optional<FirstAccessToken> findByToken(@Param("token") String token);
+
+    @Query("select t from FirstAccessToken t where t.user.id = :userId and t.isUsed = false and t.expiresAt > :now order by t.createdAt desc")
+    Optional<FirstAccessToken> findActiveByUserId(@Param("userId") Long userId, @Param("now") LocalDateTime now);
+
+    @Modifying
+    @Query("update FirstAccessToken t set t.isUsed = true, t.usedAt = :now where t.user.id = :userId and t.isUsed = false")
+    int invalidateAllByUserId(@Param("userId") Long userId, @Param("now") LocalDateTime now);
+}
+

--- a/src/main/java/com/montreal/oauth/domain/service/FirstAccessService.java
+++ b/src/main/java/com/montreal/oauth/domain/service/FirstAccessService.java
@@ -1,0 +1,57 @@
+package com.montreal.oauth.domain.service;
+
+import com.montreal.oauth.domain.entity.FirstAccessToken;
+import com.montreal.oauth.domain.entity.UserInfo;
+import com.montreal.oauth.domain.repository.IFirstAccessTokenRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class FirstAccessService {
+
+    private final IFirstAccessTokenRepository firstAccessTokenRepository;
+
+    @Value("${app.first-access.token.expiration-minutes:60}")
+    private int tokenExpirationMinutes;
+
+    @Transactional
+    public String generateFirstAccessToken(UserInfo user) {
+        firstAccessTokenRepository.invalidateAllByUserId(user.getId(), LocalDateTime.now());
+        String token = UUID.randomUUID().toString();
+        FirstAccessToken t = FirstAccessToken.builder()
+                .token(token)
+                .user(user)
+                .expiresAt(LocalDateTime.now().plusMinutes(tokenExpirationMinutes))
+                .isUsed(false)
+                .build();
+        firstAccessTokenRepository.save(t);
+        return token;
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<FirstAccessToken> findByToken(String token) {
+        return firstAccessTokenRepository.findByToken(token);
+    }
+
+    @Transactional
+    public boolean consumeFirstAccessToken(String token) {
+        Optional<FirstAccessToken> opt = firstAccessTokenRepository.findByToken(token);
+        if (opt.isEmpty()) return false;
+        FirstAccessToken t = opt.get();
+        if (t.isExpired() || t.isUsed()) return false;
+        t.setUsed(true);
+        t.setUsedAt(LocalDateTime.now());
+        firstAccessTokenRepository.save(t);
+        return true;
+    }
+}
+

--- a/src/main/java/com/montreal/oauth/domain/service/PasswordResetServiceImpl.java
+++ b/src/main/java/com/montreal/oauth/domain/service/PasswordResetServiceImpl.java
@@ -184,6 +184,8 @@ public class PasswordResetServiceImpl implements IPasswordResetService {
 
         PasswordResetToken resetToken = tokenOpt.get();
         UserInfo user = resetToken.getUser();
+        // Detecta se trata-se do primeiro cadastro de senha (primeiro acesso)
+        boolean isFirstPasswordDefinition = !user.isPasswordChangedByUser();
 
         try {
             validatePassword(newPassword);
@@ -208,7 +210,7 @@ public class PasswordResetServiceImpl implements IPasswordResetService {
 
             // Após primeiro cadastro de senha, se role exigir token no primeiro login, gere e peça validação
             boolean requiresFirstToken = user.getRoles().stream().anyMatch(r -> Boolean.TRUE.equals(r.getRequiresTokenFirstLogin()));
-            if (requiresFirstToken) {
+            if (requiresFirstToken && isFirstPasswordDefinition) {
                 userTokenService.generateAndPersist(user);
                 return ResetPasswordResult.builder()
                         .success(true)

--- a/src/main/resources/database/create_first_access_tokens_table.sql
+++ b/src/main/resources/database/create_first_access_tokens_table.sql
@@ -1,0 +1,18 @@
+-- Create first_access_tokens table
+CREATE TABLE IF NOT EXISTS first_access_tokens (
+    id BIGSERIAL PRIMARY KEY,
+    token VARCHAR(255) UNIQUE NOT NULL,
+    user_id BIGINT NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    expires_at TIMESTAMP NOT NULL,
+    used_at TIMESTAMP NULL,
+    is_used BOOLEAN DEFAULT FALSE,
+    CONSTRAINT fk_first_access_tokens_user_id FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
+-- Indexes
+CREATE INDEX IF NOT EXISTS idx_first_access_tokens_token ON first_access_tokens(token);
+CREATE INDEX IF NOT EXISTS idx_first_access_tokens_user_id ON first_access_tokens(user_id);
+CREATE INDEX IF NOT EXISTS idx_first_access_tokens_expires_at ON first_access_tokens(expires_at);
+CREATE INDEX IF NOT EXISTS idx_first_access_tokens_is_used ON first_access_tokens(is_used);
+


### PR DESCRIPTION
Ajusta a lógica para exigir token 2FA apenas no primeiro cadastro de senha (primeiro acesso), não em resets de senha subsequentes.

A user story especificou que o token deve ser exigido apenas no "primeiro acesso" (quando o usuário define a senha pela primeira vez via link de e-mail), e não em redefinições de senha futuras. Esta alteração garante que a flag `is_requires_token_first_login` seja avaliada apenas se `user.isPasswordChangedByUser()` for `false`, alinhando o comportamento do backend com este requisito.

---
<a href="https://cursor.com/background-agent?bcId=bc-2f98bb79-057b-4201-a508-5e2ef0a93e89"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2f98bb79-057b-4201-a508-5e2ef0a93e89"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

